### PR TITLE
ci: circle.ci approve

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,33 @@
+var_1: &cache_key san-dependency-cache-{{ .Branch }}-{{ checksum "package.json" }}
+
+anchor_1: &job_defaults
+  working_directory: ~/san
+  docker:
+    - image: circleci/node:8.11.2-browsers
+      environment:
+        CHROME_BIN: "/usr/bin/google-chrome"
+        COVERALLS_REPO_TOKEN: qJpQUpl7kyMzgclmsF2y5advWQlG66xl1
+
+version: 2
+jobs:
+  build:
+    <<: *job_defaults
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          key: *cache_key
+
+      - run:
+          name: install-npm-wee
+          command: npm install
+
+      - save_cache:
+          paths: 
+            - node_modules
+          key: *cache_key
+
+      - run:
+          name: test & coverage
+          command: npm run test:coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,17 @@
+sudo: false
 language: node_js
 node_js:
   - '8'
+cache:
+  directories:
+    - node_modules
 before_script:
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
-  - npm run test
-branches:
-  only:
-  - master
+script:
+  - npm run test:coverage
+notifications:
+  email:
+    on_success: never
+    on_failure: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
 script:
-  - npm run test:coverage
+  - npm run test
 notifications:
   email:
     on_success: never

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,0 @@
-machine:
-  node:
-    version: 6
-
-test:
-  override:
-    - npm run test:sauce

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "pretest": "npm run build && node ./test/ssr/build-test.js",
     "test": "npm run test:unit",
     "test:unit": "./node_modules/karma/bin/karma start ./test/karma.conf.js --single-run",
-    "test:coverage": "npm run test -- -- --coverage",
+    "test:coverage": "npm run test -- -- --coverage && cat ./coverage/report-lcov/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
     "test:e2e": "node ./test/e2e/wdio-launcher.js",
     "test:sauce": "npm run test:e2e -- modern && npm run test:e2e -- ie_family && npm run test:e2e -- mobile",
     "test:types": "tsc -p ./types/test/tsconfig.json",
@@ -48,21 +48,22 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "opener": "~1.4.0",
+    "art-template": "^4.10.2",
     "colors": "^1.0.3",
-    "watch": "^1.0.2",
+    "coveralls": "^3.0.1",
     "http-server": "^0.9.0",
     "jasmine-core": "^2.5.2",
     "karma": "^1.5.0",
     "karma-chrome-launcher": "^2.0.0",
     "karma-coverage": "^1.1.1",
     "karma-jasmine": "^1.1.0",
+    "opener": "~1.4.0",
+    "swig": "^1.4.2",
+    "uglify-js": "^2.8.22",
+    "watch": "^1.0.2",
     "wdio-jasmine-framework": "^0.3.0",
     "wdio-sauce-service": "^0.3.1",
     "wdio-spec-reporter": "^0.1.0",
-    "webdriverio": "^4.2.16",
-    "uglify-js": "^2.8.22",
-    "swig": "^1.4.2",
-    "art-template": "^4.10.2"
+    "webdriverio": "^4.2.16"
   }
 }

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -85,8 +85,13 @@ module.exports = function(config) {
     configuration.reporters.push('coverage');
     configuration.preprocessors['dist/san.dev.js'] = 'coverage';
     configuration.coverageReporter = {
-        type : 'html',
-        dir : 'coverage/'
+        reporters:[{
+            type : 'html',
+            subdir : 'coverage/'
+        },{
+            type: 'lcov',
+            subdir: 'report-lcov'
+        }]
     };
 
   }


### PR DESCRIPTION
- [ ] LGTM
- 修正circle.ci 无法跑通的问题
- 升级circle.ci 的config文件至2.0，1.0将在八月停止使用
- 增加coveralls.io 覆盖度测试报告，合并之后请把`COVERALLS_REPO_TOKEN`换成https://coveralls.io/github/baidu/san 的`repo token`
- 增加travis.ci的配置