### PR TITLE
增加一个覆盖 Component 原型的警告

### DIFF
--- a/src/view/component.js
+++ b/src/view/component.js
@@ -43,6 +43,7 @@ var elementDisposeChildren = require('./element-dispose-children');
 var elementAttach = require('./element-attach');
 var handleProp = require('./handle-prop');
 var createDataTypesChecker = require('../util/create-data-types-checker');
+var warnOverrideSuperPrototype = require('./warn-override-super-prototype');
 
 
 
@@ -54,6 +55,9 @@ var createDataTypesChecker = require('../util/create-data-types-checker');
  * @param {Object} options 初始化参数
  */
 function Component(options) { // eslint-disable-line
+
+    warnOverrideSuperPrototype(this);
+
     options = options || {};
 
     this.lifeCycle = LifeCycle.start;

--- a/src/view/warn-override-super-prototype.js
+++ b/src/view/warn-override-super-prototype.js
@@ -1,0 +1,31 @@
+/**
+ * @file 覆盖 Component 原型方法的警告
+ * @author dafrok(o.o@mug.dog)
+ */
+
+var Component = require('../view/component');
+
+// #[begin] error
+/**
+ * 覆盖 Component 原型方法的警告
+ *
+ * @param {HTMLElement} instance 组件实例
+ */
+function warnOverrideSuperPrototype(instance) {
+
+    /* eslint-disable no-console */
+    if (typeof console === 'object' && console.warn) {
+        for (var key in Component.prototype) {
+            if (instance[key] !== Component.prototype[key]) {
+                var message = '[SAN WARNING] \`' + key + '\` is a reserved key of san components. '
+                    + 'Overriding this property may cause unknown exceptions.';
+                console.warn(message);
+            }
+        }
+    }
+    /* eslint-disable no-console */
+
+}
+// #[end]
+
+exports = module.exports = warnOverrideSuperPrototype;


### PR DESCRIPTION
没有直接 throw error 是考虑到有些开发者会进行再封装（比如 yubei），更新版本后项目就 break 掉了