### PR TITLE
抽象了一个警告方法

### DIFF
--- a/src/util/warn.js
+++ b/src/util/warn.js
@@ -1,0 +1,28 @@
+/**
+ * @file 警告
+ * @author errorrik(errorrik@gmail.com)
+ */
+
+var prefix = '[SAN WARNING] ';
+
+/**
+ * 警告
+ *
+ * @param {Object} message 警告信息
+ */
+function warn(message) {
+
+    /* eslint-disable no-console */
+    if (typeof console === 'object' && console.warn) {
+        console.warn(prefix + message);
+    }
+    else {
+        // 防止警告中断调用堆栈
+        setTimeout(function () {
+            throw new Error(prefix + message);
+        });
+    }
+    /* eslint-enable no-console */
+}
+
+exports = module.exports = warn;

--- a/src/view/component.js
+++ b/src/view/component.js
@@ -44,6 +44,7 @@ var elementDisposeChildren = require('./element-dispose-children');
 var elementAttach = require('./element-attach');
 var handleProp = require('./handle-prop');
 var createDataTypesChecker = require('../util/create-data-types-checker');
+var warn = require('../util/warn');
 
 
 
@@ -58,12 +59,9 @@ function Component(options) { // eslint-disable-line
 
     /* eslint-disable no-console */
     // #[begin] error
-    if (typeof console === 'object' && console.warn) {
-        for (var key in Component.prototype) {
-            if (this[key] !== Component.prototype[key]) {
-                console.warn('[SAN WARNING] \`' + key + '\` is a reserved key of san components. '
-                    + 'Overriding this property may cause unknown exceptions.');
-            }
+    for (var key in Component.prototype) {
+        if (this[key] !== Component.prototype[key]) {
+            warn('\`' + key + '\` is a reserved key of san components. Overriding this property may cause unknown exceptions.');
         }
     }
     // #[end]

--- a/src/view/warn-event-listen-method.js
+++ b/src/view/warn-event-listen-method.js
@@ -4,6 +4,7 @@
  */
 
 var each = require('../util/each');
+var warn = require('../util/warn');
 
 // #[begin] error
 /**
@@ -30,16 +31,8 @@ function warnEventListenMethod(eventBind, owner) {
         each(eventBind.expr.name.paths, function (path) {
             paths.push(path.value);
         });
-        var message = '[SAN WARNING] ' + eventBind.name + ' listen fail,"' + paths.join('.') + '" not exist';
 
-        /* eslint-disable no-console */
-        if (typeof console === 'object' && console.warn) {
-            console.warn(message);
-        }
-        else {
-            throw new Error(message);
-        }
-        /* eslint-enable no-console */
+        warn(eventBind.name + ' listen fail,"' + paths.join('.') + '" not exist');
     }
 }
 // #[end]

--- a/src/view/warn-set-html.js
+++ b/src/view/warn-set-html.js
@@ -4,6 +4,7 @@
  */
 
 var noSetHTML = require('../browser/no-set-html');
+var warn = require('../util/warn');
 
 // #[begin] error
 /**
@@ -20,16 +21,7 @@ function warnSetHTML(el) {
     // some html elements cannot set innerHTML in old ie
     // see: https://msdn.microsoft.com/en-us/library/ms533897(VS.85).aspx
     if (noSetHTML(el)) {
-        var message = '[SAN WARNING] set html for element "' + el.tagName
-            + '" may cause an error in old IE';
-        /* eslint-disable no-console */
-        if (typeof console === 'object' && console.warn) {
-            console.warn(message);
-        }
-        else {
-            throw new Error(message);
-        }
-        /* eslint-enable no-console */
+        warn('set html for element "' + el.tagName + '" may cause an error in old IE');
     }
 }
 // #[end]


### PR DESCRIPTION
san 的警告在 `console.warn` 不存在的情况下会 fallback 到 throw Error，这样会直接跳出调用堆栈，和原本的 `console.warn` 行为不一致可能造成不必要的麻烦，所以给 throw 外面包了一层 `setTimeout`。

然后又发现有三个地方用到这个逻辑，重复代码太多，所以封装了一下。