### PR TITLE
fix video autoplay in background while component tagName is video

### DIFF
--- a/src/view/preheat-a-node.js
+++ b/src/view/preheat-a-node.js
@@ -61,7 +61,7 @@ function preheatANode(aNode) {
             else {
                 var sourceNode;
                 if (isBrowser && aNode.tagName
-                    && !/^(template|slot|select|input|option|button)$/i.test(aNode.tagName)
+                    && !/^(template|slot|select|input|option|button|video|audio)$/i.test(aNode.tagName)
                 ) {
                     sourceNode = createEl(aNode.tagName);
                 }


### PR DESCRIPTION
san中的子组件如果定义成h5原生标签同名的会有问题，如下面h5例子，也能复现问题，会有视频声音播放：

```html
<!DOCTYPE html>
<html>
<head>
    <meta charset="utf-8">
    <title>start - hello</title>
</head>

<body>
    san2
    <!-- <script src="./san/san.dev.js"></script> -->
    <script src="https://unpkg.com/san@3.7.5/dist/san.min.js"></script>

    <script>
    var Child = san.defineComponent({
        template: '<p on-click="toggleProps">aaaaaa child props: {{props}}</p>',
        initData: function () {
            return {
            };
        },
        toggleProps() {
            this.data.set('props', false);
        }
    });

    var MyApp = san.defineComponent({
        template: `
            <div>
                <video s-ref="video" id="myde" style="width: 100px; height: 100px; background-color: gray;" duration="10"
                    src="http://wxsnsdy.tc.qq.com/105/20210/snsdyvideodownload?filekey=30280201010421301f0201690402534804102ca905ce620b1241b726bc41dcff44e00204012882540400&bizid=1023&hy=SH&fileparam=302c020101042530230204136ffd93020457e3c4ff02024ef202031e8d7f02030f42400204045a320a0201000400"
                    autoplay="{{true}}" loop></video>
            </div>
        `,
        components: {
            'video': Child
        },
        attached() {
            console.log('attached', this.ref('video'));
        },
        initData: function () {
            return {
                parent: true
            };
        },
        toggleParent() {
            this.data.set('parent', false);
        }
    });
    var myApp = new MyApp();
    // myApp.attach(document.body);
    </script>
</body>
</html>
```

如果把子组件命名为`img`，给一个图片src，则会在network中看到请求图片

上述demo中流程：
defineComponent 定义组件，返回ComponentClass构造函数

new myApp()调用ComponentClass构造函数
其内部调Component 构造函数
compileComponent生成aNode
preheatANode 递归调analyseANodeHotspot对子组件的props、directive、sourceNode预生成、处理
其中在analyseANodeHotspot，会createEl标签名创建sourceNode并且
	1. 常量props直接赋值给sourceNode 
	2. 数据绑定的props放到dynamicProps中后续处理
这就相当于直接在浏览器console输入如下代码：

```
v = document.createElement('video');
v.src = 'http://wxsnsdy.tc.qq.com/105/20210/snsdyvideodownload?filekey=30280201010421301f0201690402534804102ca905ce620b1241b726bc41dcff44e00204012882540400&bizid=1023&hy=SH&fileparam=302c020101042530230204136ffd93020457e3c4ff02024ef202031e8d7f02030f42400204045a320a0201000400';
v.autoplay = true;
```

为什么autoplay或者src写成变量没问题，因为静态属性会通过setAttribute赋值，动态props会丢到dynamicProps中后续处理