### PR TITLE
do not refresh if irrelevant props modified when san-for used on an object

### DIFF
--- a/src/view/for-node.js
+++ b/src/view/for-node.js
@@ -253,10 +253,18 @@ ForNode.prototype._update = function (changes) {
             // 就是这么暴力
             // 不推荐使用for遍历object，用的话自己负责
             this.listData = listData;
-            var me = this;
-            this._disposeChildren(null, function () {
-                me._createChildren();
-            });
+
+            var isListChanged;
+            for (var cIndex = 0; !isListChanged && cIndex < changes.length; cIndex++) {
+                isListChanged = changeExprCompare(changes[cIndex].expr, this.param.value, this.scope);
+            }
+            var dataHotspot = this.aNode.hotspot.data;
+            if (isListChanged || dataHotspot && changesIsInDataRef(changes, dataHotspot)) {
+                var me = this;
+                this._disposeChildren(null, function () {
+                    me._createChildren();
+                });
+            }
         }
         else {
             this._updateArray(changes, listData);

--- a/test/for-directive.spec.js
+++ b/test/for-directive.spec.js
@@ -2854,6 +2854,43 @@ describe("ForDirective", function () {
 
     });
 
+    it("render object, do nothing if irrelevant prop modified", function (done) {
+        var MyComponent = san.defineComponent({
+            template: '<ul><li san-for="p,i in persons" title="{{p}}">{{i}}-{{p}}</li></ul>'
+        });
+
+        var myComponent = new MyComponent({
+            data: {
+                irrelevantProp: 'a',
+                persons: {
+                    'erik': 'errorrik@gmail.com',
+                    'otakustay': 'otakustay@gmail.com'
+                }
+            }
+        });
+
+        var wrap = document.createElement('div');
+        document.body.appendChild(wrap);
+        myComponent.attach(wrap);
+
+        var lis = wrap.getElementsByTagName('li');
+        var keptLis = Array.prototype.slice.call(lis);
+
+        myComponent.data.set('irrelevantProp', 'b');
+        myComponent.nextTick(function () {
+            var lis = wrap.getElementsByTagName('li');
+
+            expect(myComponent.data.get('irrelevantProp')).toBe('b');
+            expect(lis.length).toBe(2);
+            expect(lis[0] === keptLis[0]).toBe(true);
+            expect(lis[1] === keptLis[1]).toBe(true);
+
+            myComponent.dispose();
+            document.body.removeChild(wrap);
+            done();
+        });
+    });
+
     it("render object, start with undefined", function (done) {
         var MyComponent = san.defineComponent({
             template: '<ul><li san-for="p,i in dep.persons" title="{{p}}">{{i}}-{{p}}</li></ul>'


### PR DESCRIPTION
Make view do not refresh if irrelevant sibling props modified when `san-for` is used on an object.