### PR TITLE
 fix category id repeat & fix formatedate

### DIFF
--- a/example/todos-esnext/src/filters.js
+++ b/example/todos-esnext/src/filters.js
@@ -1,9 +1,8 @@
 import moment from 'moment';
 
 export const formatDate = (value, format) => {
-    return value instanceof Date
-        ? moment(value).format(format)
-        : '';
+    let time = moment(value).format(format);
+    return  time ? time : '';
 };
 
 export const formatHour = hour => {

--- a/example/todos-esnext/src/service.js
+++ b/example/todos-esnext/src/service.js
@@ -131,9 +131,9 @@ export default {
 
     addCategory(category) {
         let first = data.category[0];
-        let id = 1;
+        let id;
         if (first) {
-            id = first.id + 1;
+            id = data.category.length + 1;
         }
 
         category = extend({}, category);


### PR DESCRIPTION
目前的todos-esnext中存在以下问题：
1.添加新的分类时，会出现所有的新分类的id都与已有分类的id重复。体现在选中新加的分类时，与新分类id一样的分类也会显示被选中，显示某一分类下的内容时，两个id相同的内容会同时显示出来。
2.todolist预期完成时间无法正常显示。
故做以下修改，望采纳~