### PR TITLE
fix: type for SanData

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -8,7 +8,7 @@ declare namespace San {
 
     type SanEventListener<T, N> = (e: SanEvent<T, N>) => any;
     interface SanData<T> {
-        new(data?: {}, parent?: SanData<{}>);
+        new(data?: {}, parent?: SanData<{}>): SanData<T>;
         parent: SanData<{}>;
         raw: T;
 
@@ -20,7 +20,7 @@ declare namespace San {
         setTypeChecker(checker: () => void): void;
 
         fire(change: SanDataChangeInfo): void;
-        get(expr: string | ExprAccessorNode): any;
+        get(expr?: string | ExprAccessorNode): any;
         set(expr: string | ExprAccessorNode, value: any, option?: SanDataChangeOption): void;
         merge(expr: string | ExprAccessorNode, source: {}, option?: SanDataChangeOption): void;
         apply(expr: string | ExprAccessorNode, changer: (oldval: {}) => {}, option?: SanDataChangeOption): void;


### PR DESCRIPTION
SanData 的类型缺一些东西，在这个 PR 中补充。这个变更是 https://github.com/searchfe/san-ssr/pull/18 中的一个依赖。

变更内容：

* Add return value for SanData `new()` method, for use cases where
  `noImplicitAny` option is enabled
* Make `get()` argument  `expr` optional, for cases when getting
  the whole data
