### PR TITLE
自关闭标签和 WHATWG/HTML5 保持一致

### DIFF
--- a/src/browser/auto-close-tags.js
+++ b/src/browser/auto-close-tags.js
@@ -14,6 +14,6 @@ var splitStr2Obj = require('../util/split-str-2-obj');
  *
  * @type {Object}
  */
-var autoCloseTags = splitStr2Obj('area,base,br,col,embed,hr,img,input,keygen,param,source,track,wbr');
+var autoCloseTags = splitStr2Obj('area,base,br,col,embed,hr,img,input,link,meta,param,source,track,wbr');
 
 exports = module.exports = autoCloseTags;

--- a/test/parse-template-error.spec.js
+++ b/test/parse-template-error.spec.js
@@ -33,7 +33,7 @@ describe('parseTemplate', function () {
 
     var AUTO_CLOSE_TAGS = [
         'area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input',
-        'keygen', 'param', 'source', 'track', 'wbr'
+        'link', 'meta', 'param', 'source', 'track', 'wbr'
     ];
 
     var AUTO_CLOSE_TAGS_MAP = {};


### PR DESCRIPTION
auto-close-tags 和 HTML5 中的 [void elements 列表](https://html.spec.whatwg.org/multipage/syntax.html#void-elements) 保持一致：增加 link、meta；去掉 keygen。

FIX
- 自关闭标签的开始标签上 `/` 是可选的（见 [syntax.html#start-tags](https://html.spec.whatwg.org/multipage/syntax.html#start-tags)），目前 link、meta 在 san 中必须加 `/`。
- 额外的问题是加 `/` 后又会触发 fecs 的 `Void tags should not close themeselves with "/"`。

BREAKING CHANGES
- keygen 不再是自关闭标签，必须手动关闭。