### PR TITLE
建议直接使用 setAttribute 来修改属性，简化代码

### DIFF
--- a/src/view/get-prop-handler.js
+++ b/src/view/get-prop-handler.js
@@ -45,20 +45,11 @@ var HTML_ATTR_PROP_MAP = {
 
 function defaultElementPropHandler(el, value, name) {
     var propName = HTML_ATTR_PROP_MAP[name] || name;
-    var valueNotNull = value != null;
-
-    // input 的 type 是个特殊属性，其实也应该用 setAttribute
-    // 但是 type 不应该运行时动态改变，否则会有兼容性问题
-    // 所以这里直接就不管了
-    if (propName in el) {
-        el[propName] = valueNotNull ? value : '';
+    if (value != null) {
+        el.setAttribute(propName, value);
     }
-    else if (valueNotNull) {
-        el.setAttribute(name, value);
-    }
-
-    if (!valueNotNull) {
-        el.removeAttribute(name);
+    else {
+        el.removeAttribute(propName);
     }
 }
 
@@ -190,15 +181,7 @@ var elementPropHandlers = {
 
     button: {
         disabled: boolPropHandler,
-        autofocus: boolPropHandler,
-        type: function (el, value) {
-            if (value != null) {
-                el.setAttribute('type', value);
-            }
-            else {
-                el.removeAttribute(name);
-            }
-        }
+        autofocus: boolPropHandler
     }
 };
 


### PR DESCRIPTION
建议直接使用 setAttribute 来修改属性，因为兼容性不可能完全考虑完整  
按此修改后，可以在 ie8 下正常运行

正如在 #492 中所提到  
> 这类细碎的浏览器DOM操作兼容性问题，框架不打算全部抹平，否则体积和维护性就会爆炸了。