### PR TITLE
修复：nbsp 的值、3.9.0 的 types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ ChangeLog
 + 【优化】- template 的节点属性声明支持不以 `"'` 包围，提升 html 兼容性
 + 【优化】- 对组件 template 编译的 ANode 信息进行了精简和微调
 + 【优化】- trackBy 循环更新时，如果循环目标是普通节点，对乱序节点进行复用，避免丢弃重建
++ 【优化】- `SanData#get()` 支持类型参数 `data.get<string>()`
 + 【bug修复】- 当组件根节点不为 HTMLElement 时，attached 中的数据变更，未触发视图更新
-
++ 【bug修复】- `&nbsp;` 被解析为 `\u0020`（space），修复为 `\u00a0`（non-breaking space）
 
 3.8.5
 -------

--- a/src/util/decode-html-entity.js
+++ b/src/util/decode-html-entity.js
@@ -10,7 +10,7 @@
 var ENTITY_DECODE_MAP = {
     lt: '<',
     gt: '>',
-    nbsp: ' ',
+    nbsp: '\u00a0',
     quot: '\"',
     emsp: '\u2003',
     ensp: '\u2002',

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -19,7 +19,7 @@ declare namespace San {
         setTypeChecker(checker: () => void): void;
 
         fire(change: SanDataChangeInfo): void;
-        get(expr?: string | ExprAccessorNode): any;
+        get<D = any>(expr?: string | ExprAccessorNode): D;
         set(expr: string | ExprAccessorNode, value: any, option?: SanDataChangeOption): void;
         merge(expr: string | ExprAccessorNode, source: {}, option?: SanDataChangeOption): void;
         apply(expr: string | ExprAccessorNode, changer: (oldval: {}) => {}, option?: SanDataChangeOption): void;
@@ -155,14 +155,12 @@ declare namespace San {
 
     interface ExprNodeTpl<T extends ExprType> {
         type: T;        // 如果只有这一个属性，去掉泛型更可读
-        raw: string;
         value?: any;    // 在 eval 会统一处理，事实上作用于 null, string, number
         parenthesized?: boolean; // 在 read parenthesized expr 会统一设置
     }
     type ExprNode = ExprNodeTpl<any>;
     interface ExprStringNode extends ExprNodeTpl<ExprType.STRING> {
         value: string;
-        literal?: string;
     }
     interface ExprNumberNode extends ExprNodeTpl<ExprType.NUMBER> {
         value: number;
@@ -245,14 +243,14 @@ declare namespace San {
     interface ANodeProperty {
         name: string;
         expr: ExprNode;
-        raw: string;
+        noValue?: 1;
         x?: number;
     }
 
     interface ANode {
         isText?: boolean;
         text?: string;
-        textExpr?: ExprTextNode;
+        textExpr?: ExprTextNode | ExprStringNode;
         children?: ANode[];
         props: ANodeProperty[];
         events: SanIndexedList<ExprNode>;
@@ -265,7 +263,7 @@ declare namespace San {
     }
 
     interface ATextNode extends ANode {
-        textExpr: ExprTextNode;
+        textExpr: ExprTextNode | ExprStringNode;
     }
 
     interface ATemplateNode extends ANode {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -311,6 +311,7 @@ declare namespace San {
     function parseExpr(template: string): ExprNode;
     function evalExpr<T, D extends SanComponent<{}>>(expr: ExprNode, data: SanData<T>, owner?: D): any;
     function parseTemplate(template: string, options?: ParseTemplateOption): ANode;
+    function parseComponentTemplate(componentClass: ComponentConstructor<{}, {}>): ANode;
     function inherits(childClazz: (...args: any[]) => void, parentClazz: ComponentConstructor<{}, {}>): void;
     function nextTick(doNextTick: () => any): void;
     const DataTypes: {


### PR DESCRIPTION
有两个 commit：

1. 3.9.0  的 types 更新：
    - `textExpr` 在 ANode 压缩后可能是 `ATextNode`，也可能是 `AStringNode`
    - 干掉 `raw` 和 `literal`，新增 `noValue`
    - `SanData#get()` 的一个易用性功能 `get<string>()` 来得到 string，之前需要 `(get() as string)`
2. nbsp 应该映射到 unicode 00a0 (hex)，之前映射到了 20(hex)