### PR TITLE
feat: identify subcomponent with hot tag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "san",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/view/preheat-a-node.js
+++ b/src/view/preheat-a-node.js
@@ -28,7 +28,7 @@ var Element = require('./element');
  *
  * @param {Object} aNode 要预热的ANode
  */
-function preheatANode(aNode) {
+function preheatANode(aNode, skipTags) {
     var stack = [];
 
     function recordHotspotData(expr, notContentData) {
@@ -87,7 +87,7 @@ function preheatANode(aNode) {
                 each(aNode.props, function (prop) {
                     aNode.hotspot.binds.push({
                         name: kebab2camel(prop.name),
-                        expr: prop.noValue != null 
+                        expr: prop.noValue != null
                             ? {type: ExprType.BOOL, value: true}
                             : prop.expr,
                         x: prop.x,
@@ -197,8 +197,16 @@ function preheatANode(aNode) {
                     aNode = aNode.forRinsed;
                 }
 
-                if (hotTags[aNode.tagName]) {
-                    aNode.Clazz = Element;
+                if (skipTags !== 'all' && hotTags[aNode.tagName]) {
+                    if (skipTags[aNode.tagName]) {
+                        // #[begin] error
+                        /* eslint-disable max-len */
+                        warn('\`' + aNode.tagName + '\` is a reserved tag name. Using this to identify component may cause unknown exceptions.');
+                        /* eslint-enable max-len */
+                        // #[end]
+                    } else {
+                        aNode.Clazz = Element;
+                    }
                 }
                 else {
                     switch (aNode.tagName) {

--- a/test/component.spec.js
+++ b/test/component.spec.js
@@ -4971,7 +4971,7 @@ describe("Component", function () {
             expect(as.length).toBe(1);
             expect(as[0].innerHTML).toBe('github');
             expect(bs[0].innerHTML).toBe('san');
-            
+
             myComponent.data.set('hidd', true);
             myComponent.nextTick(function () {
                 var as = wrap.getElementsByTagName('a');
@@ -5063,7 +5063,7 @@ describe("Component", function () {
                         linkText: 'HomePage'
                     }
                 ]
-                
+
             }
         });
 
@@ -5134,7 +5134,7 @@ describe("Component", function () {
         document.body.appendChild(wrap);
         myComponent.attach(wrap);
 
-        
+
         expect(myComponent.el.tagName).toBe('H3');
         expect(myComponent.el.className).toBe('');
         expect(!!myComponent.el.id).toBeFalsy();
@@ -5188,7 +5188,7 @@ describe("Component", function () {
         document.body.appendChild(wrap);
         myComponent.attach(wrap);
 
-        
+
         expect(myComponent.el.tagName).toBe('H3');
         expect(myComponent.el.className).toBe('');
         expect(!!myComponent.el.id).toBeFalsy();
@@ -5262,7 +5262,7 @@ describe("Component", function () {
         var myComponent = new MyComponent({
             data: {
                 list: [
-                    {name: 'err', email: 'errorrik@gmail.com'}, 
+                    {name: 'err', email: 'errorrik@gmail.com'},
                     {name: 'lee', email: 'leeight@gmail.com'},
                     {name: 'gray', email: 'xxx@outlook.com'}
                 ]
@@ -5513,8 +5513,8 @@ describe("Component", function () {
             as = wrap.getElementsByTagName('a');
             expect(as.length).toBe(1);
             expect(as[0].innerHTML).toBe('github');
-            
-            
+
+
             myComponent.data.set('hidd', true);
             myComponent.nextTick(function () {
                 var as = wrap.getElementsByTagName('a');
@@ -5541,14 +5541,80 @@ describe("Component", function () {
                     expect(as.length).toBe(1);
                     expect(as[0].innerHTML).toBe('github');
                     expect(bs[0].innerHTML).toBe('san');
-                    
+
                     myComponent.dispose();
                     document.body.removeChild(wrap);
                     done();
                 });
-                
+
             });
         });
+    });
+    it("identify subcomponent with reserved hot tag", function() {
+        var Label = san.defineComponent({
+            template: '<span title="{{text}}">{{text}}</span>'
+        });
+
+        var MyComponent = san.defineComponent({
+            components: {
+                'b': Label
+            },
+
+            template: '<div><b text="{{name}}"></b></div>',
+
+            initData: function() {
+                return { name: 'erik' };
+            }
+        });
+
+        var myComponent = new MyComponent();
+
+        var wrap = document.createElement('div');
+        document.body.appendChild(wrap);
+        myComponent.attach(wrap);
+
+        var span = wrap.getElementsByTagName('span')[0];
+        expect(span.innerText).toBe('erik');
+        expect(span.title).toBe('erik');
+
+        myComponent.dispose();
+        document.body.removeChild(wrap);
+
+    });
+
+    it("identify subcomponent with reserved hot tag with getComponentType", function() {
+        var Label = san.defineComponent({
+            template: '<span title="{{text}}">{{text}}<i>{{tip}}</i></span>'
+        });
+        var MyComponent = san.defineComponent({
+            getComponentType: function(aNode) {
+                if (aNode.tagName === 'b') {
+                    return Label;
+                }
+            },
+
+            template: '<div><b text="{{name}}" tip="{{company}}"></b></div>',
+
+            initData: function() {
+                return { name: 'erik', company: 'baidu' };
+            }
+        });
+
+        var myComponent = new MyComponent();
+
+        var wrap = document.createElement('div');
+        document.body.appendChild(wrap);
+        myComponent.attach(wrap);
+
+        var span = wrap.getElementsByTagName('span')[0];
+        expect(span.innerText).toBe('erikbaidu');
+        expect(span.title).toBe('erik');
+
+        var i = wrap.getElementsByTagName('i')[0];
+        expect(i.innerText).toBe('baidu');
+
+        myComponent.dispose();
+        document.body.removeChild(wrap);
     });
 });
 


### PR DESCRIPTION
如果不兼容getComponentType还好，但是如果要兼容getComponentType，见component.spec.js中名为”identify subcomponent with reserved hot tag with getComponentType“的case。

想到的办法只有尝试看能不能用getComponentType(mockHotTagANode, data)来看看是否返回组件，但是因为无法得知getComponentType的具体实现，只能mock该方法使用tagName为hottag时的逻辑，如果用户是利用使用hottag的aNode上的其他属性做逻辑判断，则会漏判（概率比较小）。

此外，还有一个sideeffect就是，为了兼容getComponentType，只能在拿到this.data之后去preheat，这跟expose的phase矛盾了。

所以此PR请erik看一下，是否要兼容getComponentType的case，如果要兼容就有上面说的两个问题。

如果不兼容，那就轻松愉快了。