### PR TITLE
fix aPack from parseTemplate

### DIFF
--- a/src/view/component.js
+++ b/src/view/component.js
@@ -111,7 +111,11 @@ function Component(options) { // eslint-disable-line
     if (!proto.hasOwnProperty('aNode')) {
         var aPack = clazz.aPack || proto.hasOwnProperty('aPack') && proto.aPack;
         if (aPack) {
-            proto.aNode = unpackANode(aPack);
+            var aNode = unpackANode(aPack);
+            if(aPack.indexOf('class') < 0) {
+                aNode = parseComponentTemplate(clazz, aNode);
+            }
+            proto.aNode = aNode;
             clazz.aPack = proto.aPack = null;
         }
         else {

--- a/src/view/parse-component-template.js
+++ b/src/view/parse-component-template.js
@@ -20,16 +20,16 @@ var createAccessor = require('../parser/create-accessor');
  * @param {Function} ComponentClass 组件类
  * @return {ANode}
  */
-function parseComponentTemplate(ComponentClass) {
+function parseComponentTemplate(ComponentClass, aNode) {
     var proto = ComponentClass.prototype;
 
-    
-    var tplANode = parseTemplate(ComponentClass.template || proto.template, {
+
+    var tplANode = aNode || parseTemplate(ComponentClass.template || proto.template, {
         trimWhitespace: proto.trimWhitespace || ComponentClass.trimWhitespace,
         delimiters: proto.delimiters || ComponentClass.delimiters
     });
 
-    var aNode = tplANode.children[0];
+    aNode = tplANode.children[0];
     if (aNode && aNode.textExpr) {
         aNode = null;
     }
@@ -80,7 +80,7 @@ function parseComponentTemplate(ComponentClass) {
 
                 case 'id':
                     extraPropExists[prop.name] = true;
-                
+
             }
         }
 
@@ -127,8 +127,8 @@ function parseComponentTemplate(ComponentClass) {
         }
 
         if (!extraPropExists.id) {
-            aNode.props.push({ 
-                name: 'id', 
+            aNode.props.push({
+                name: 'id',
                 expr: createAccessor([{
                     type: ExprType.STRING,
                     value: 'id'

--- a/test/component-compile.spec.js
+++ b/test/component-compile.spec.js
@@ -100,4 +100,31 @@ describe("Component Compile", function () {
         });
 
     });
+
+    it("use aPack from parseTemplate", function () {
+
+        var File = san.defineComponent({
+            // template: '<span>erik</span>',
+            aPack: [1,,1,1,"span",1,,3,"erik"]
+        });
+
+        var Folder = san.defineComponent({
+            template: '<div><f class="customClass" id="customId" style="color: red;" /></div>',
+            components: {
+                f: File
+            }
+        });
+
+        var myComponent = new Folder();
+
+        var wrap = document.createElement('div');
+        document.body.appendChild(wrap);
+        myComponent.attach(wrap);
+
+        var span = wrap.getElementsByTagName('span')[0];
+        expect(span.id).toBe('customId');
+        expect(span.style.color).toBe('red');
+        expect(span.getAttribute('class')).toBe('customClass');
+
+    });
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -311,7 +311,7 @@ declare namespace San {
     function parseExpr(template: string): ExprNode;
     function evalExpr<T, D extends SanComponent<{}>>(expr: ExprNode, data: SanData<T>, owner?: D): any;
     function parseTemplate(template: string, options?: ParseTemplateOption): ANode;
-    function parseComponentTemplate(componentClass: ComponentConstructor<{}, {}>): ANode;
+    function parseComponentTemplate(componentClass: ComponentConstructor<{}, {}>, aNode?: ANode): ANode;
     function inherits(childClazz: (...args: any[]) => void, parentClazz: ComponentConstructor<{}, {}>): void;
     function nextTick(doNextTick: () => any): void;
     const DataTypes: {


### PR DESCRIPTION
支持 #519 。
子组件使用parseTemplate导出的aPack，会丢失style/class/id占位，因此组件初始化aNode需要考虑这种情况。
