### PR TITLE
feat: 组件派发消息时通知san-devtools

### DIFF
--- a/src/view/component.js
+++ b/src/view/component.js
@@ -495,7 +495,9 @@ Component.prototype._calcComputed = function (computedExpr) {
  */
 Component.prototype.dispatch = function (name, value) {
     var parentComponent = this.parentComponent;
-
+    // #[begin] devtool
+    var dispatched = false;
+    // #[end]
     while (parentComponent) {
         var receiver = parentComponent.messages[name] || parentComponent.messages['*'];
         if (typeof receiver === 'function') {
@@ -503,11 +505,17 @@ Component.prototype.dispatch = function (name, value) {
                 parentComponent,
                 {target: this, value: value, name: name}
             );
+            // #[begin] devtool
+            dispatched = true;
+            // #[end]
             break;
         }
 
         parentComponent = parentComponent.parentComponent;
     }
+    // #[begin] devtool
+    emitDevtool('event-dispatch', dispatched ? parentComponent : null, {target: this, value: value, name: name});
+    // #[end]    
 };
 
 /**


### PR DESCRIPTION
 san-devtools 需要增加 event 面板，用于追踪 message 消息，比如哪个组件触发了 dispatch，传递的值是什么，哪个组件捕获到了。同时还能排除那些未用到的或者说多余的 dispatch 动作。