### PR TITLE
fix: apack lose parents-child props, issues#553

### DIFF
--- a/src/view/component.js
+++ b/src/view/component.js
@@ -111,7 +111,7 @@ function Component(options) { // eslint-disable-line
     if (!proto.hasOwnProperty('aNode')) {
         var aPack = clazz.aPack || proto.hasOwnProperty('aPack') && proto.aPack;
         if (aPack) {
-            proto.aNode = unpackANode(aPack);
+            proto.aNode = parseComponentTemplate(clazz, unpackANode(aPack));
             clazz.aPack = proto.aPack = null;
         }
         else {

--- a/src/view/parse-component-template.js
+++ b/src/view/parse-component-template.js
@@ -20,16 +20,19 @@ var createAccessor = require('../parser/create-accessor');
  * @param {Function} ComponentClass 组件类
  * @return {ANode}
  */
-function parseComponentTemplate(ComponentClass) {
+function parseComponentTemplate(ComponentClass, tplANode) {
     var proto = ComponentClass.prototype;
+    var aNode;
 
-    
-    var tplANode = parseTemplate(ComponentClass.template || proto.template, {
-        trimWhitespace: proto.trimWhitespace || ComponentClass.trimWhitespace,
-        delimiters: proto.delimiters || ComponentClass.delimiters
-    });
-
-    var aNode = tplANode.children[0];
+    if (!tplANode) {
+        tplANode = parseTemplate(ComponentClass.template || proto.template, {
+            trimWhitespace: proto.trimWhitespace || ComponentClass.trimWhitespace,
+            delimiters: proto.delimiters || ComponentClass.delimiters
+        });
+        aNode = tplANode.children[0];
+    } else {
+        aNode = tplANode;
+    }
     if (aNode && aNode.textExpr) {
         aNode = null;
     }


### PR DESCRIPTION
修复这个问题：https://github.com/baidu/san/issues/553

因为 apack 生成于编译阶段（基于 ast）， 所以只处理了当前组件的 template to apack，而在 apack 转成 aNode 时候，缺失了父组件传给子组件的数据，比如 class，style；