### PR TITLE
修复元素的布尔属性用驼峰命名且值为false时的表现和预期相反的问题

### DIFF
--- a/src/view/get-prop-handler.js
+++ b/src/view/get-prop-handler.js
@@ -56,7 +56,7 @@ function defaultElementPropHandler(el, value, name) {
         el.setAttribute(name, value);
     }
 
-    if (!valueNotNull) {
+    if (!valueNotNull || value === false) {
         el.removeAttribute(name);
     }
 }


### PR DESCRIPTION
以下举例说明该问题。

不使用框架时，以下两种写法，虽然布尔属性的大小写不一致，但是表现是一致的。
```html
<input autofocus>
```
```html
<input autoFocus>
```
所以，使用 San 时，预期以下两种写法的表现也应该一致：
```html
<input autofocus="{{false}}">
```
```html
<input autoFocus="{{false}}">
```
但实际上不一致，第一种写法不会自动 focus，而第二种写法会自动 focus。

第二种写法不符合预期的原因是，第二种写法产出的 HTML 是这样：
```html
<input autofocus="false">
```
> 在 HTML 中，布尔属性只要存在，它实际的值就是 `ture`，无论赋给它什么值（这里赋给了它字符串"false"）。可参考 [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes#boolean_attributes)。

而第二种写法之所以产出的 HTML 会是这样的，是因为执行了：
```js
// 该行代码在代码库中的位置：https://github.com/baidu/san/blob/master/src/view/get-prop-handler.js#L56
el.setAttribute('autoFocus', false);
```
> `setAttribute` 会把传入的第二个参数转为字符串。可参考 [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/setAttribute#syntax)。

综上所述，我的解决办法是：
当用户设置的布尔属性的值为 `false` 时，使用 `removeAttribute` 移除该布尔属性。

PS：会出现这个问题的情况
当用户写的布尔属性的名字的大小写错误时，就会出现这个问题（原生的不会有这个问题）。
