### PR TITLE
fix: replace oldValue with value

### DIFF
--- a/src/view/component.js
+++ b/src/view/component.js
@@ -961,7 +961,7 @@ Component.prototype.watch = function (dataName, listener) {
                 catch (e) {
                     handleError(e, me, 'watch:' + dataName);
                 }
-                oldValue = newValue;
+                value = newValue;
             }
         }
     });


### PR DESCRIPTION
将 oldValue 替换为 value，否则当监听的数据改变时， value 值没得到更新而一直为初始值。
假如数据初始值是1，这样改变： 1->2->3->1，那么 3->1 这次改变不能触发 listener。