### PR TITLE
fix: baidu/san-ssr#125

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "san",
-  "version": "3.10.6",
+  "version": "3.10.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6876,9 +6876,9 @@
       "dev": true
     },
     "san-html-cases": {
-      "version": "3.10.14",
-      "resolved": "https://registry.npmjs.org/san-html-cases/-/san-html-cases-3.10.14.tgz",
-      "integrity": "sha512-5Bw+0+Hcci5NQuGl2WHTh8bE2BOA5CLYrLvscGaVCenFxTo75HBhit4bZF0w0mp1NAollqh2nALUljSKYwKeLw==",
+      "version": "3.10.19",
+      "resolved": "https://registry.npmjs.org/san-html-cases/-/san-html-cases-3.10.19.tgz",
+      "integrity": "sha512-m7feB0Z1cUJnfmPcz6m3DsB9P7jtEjNqvTEw6EEVjfO2s1wp4NNDEBAY7oqhi1oUwp+rkFkFKOE9L7lVZQg5qw==",
       "dev": true
     },
     "saucelabs": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "mustache": "^3.0.1",
     "opener": "^1.5.1",
     "san-anode-cases": "^3.10.1",
-    "san-html-cases": "^3.10.14",
+    "san-html-cases": "^3.10.19",
     "source-map": "^0.7.3",
     "swig-templates": "^2.0.3",
     "uglify-js": "^2.8.22",

--- a/src/view/slot-node.js
+++ b/src/view/slot-node.js
@@ -109,7 +109,7 @@ function SlotNode(aNode, parent, scope, owner, reverseWalker) {
         var hasFlagComment;
 
         // start flag
-        if (reverseWalker.current && reverseWalker.current.nodeType === 8) {
+        if (reverseWalker.current && reverseWalker.current.nodeType === 8 && reverseWalker.current.data === 's-slot') {
             this.sel = reverseWalker.current;
             hasFlagComment = 1;
             reverseWalker.goNext();


### PR DESCRIPTION
san-ssr 的输出格式较之前的提交：https://github.com/baidu/san/commit/8f07367f809cd1e57cfcfc9976e942e872a21237 https://github.com/baidu/san/commit/cd68628757bb95c8b65bb987462a8e773bd5d72c 已经有了较大变化。
目前 san-ssr 的渲染结果中，fragment 会输出 comment 标记，但是 slot 不会输出 comment 标记。
在反解时遇到 slot 尝试消耗 comment 标记与 san-ssr 行为不一致，会引入其他问题，因此将 slot-node 中相关代码移除。

测试了其他 case，没有发现问题：

```html
<!DOCTYPE html>
<html>
<head>
    <meta charset="utf-8">
    <title>start - for</title>
</head>

<body>
    <script src="./node_modules/san/dist/san.js"></script>
    <div id="root">
        <div><!--s-data:{"aaa":"123"}--><div><!--s-text-->123456123456<!--/s-text--></div></div>
    </div>
    <script>

    let container = san.defineComponent({
        template: `
            <div>
                <slot/>
            </div>
        `
    })
    let MyApp = san.defineComponent({
        components: { 'x-l': container },
        template: '<div><x-l>{{ aaa | raw }}456{{ aaa | raw }}456</x-l></div>',
        initData() {
            return {
                aaa: '123'
            }
        }

    })
    let myApp = new MyApp({el: document.getElementById('root').firstElementChild});
    myApp.attach(document.getElementById('root'));
    </script>
</body>
</html>
```

更新了 san-html-cases 版本，增加了 slot 中嵌套 fragment 的情况。