### PR TITLE
fix readEqualityExpr

### DIFF
--- a/src/parser/read-equality-expr.js
+++ b/src/parser/read-equality-expr.js
@@ -34,7 +34,7 @@ function readEqualityExpr(walker) {
                 return {
                     type: ExprType.BINARY,
                     operator: code,
-                    segs: [expr, readRelationalExpr(walker)]
+                    segs: [expr, readEqualityExpr(walker)]
                 };
             }
 


### PR DESCRIPTION
Some errors  when parseTemplate as {{1 != 1 == 0 }} 