### PR TITLE
fix unsafe-eval

### DIFF
--- a/src/view/component.js
+++ b/src/view/component.js
@@ -161,16 +161,22 @@ function Component(options) { // eslint-disable-line
                 var stumpText = stumpMatch[1];
 
                 // fill component data
-                options.data = JSON.parse(stumpText
-                        .replace(/^[\s\n]*/, '')
-                        .replace(
-                            /"(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})\.\d+Z"/g,
-                            function (match, y, mon, d, h, m, s) {
-                                return 'new Date(' + (+y) + ',' + (+mon) + ',' + (+d)
-                                    + ',' + (+h) + ',' + (+m) + ',' + (+s) + ')';
-                            }
-                        )
-                );
+                stumpText = stumpText
+                    .replace(/^[\s\n]*/, '')
+                    .replace(/\\(.)/g, function ($0, $1) { // 去掉转移符
+                        return $1;
+                    });
+
+                options.data = JSON.parse(stumpText, function (key, value) {
+                    var matched = [];
+                    if (typeof value === 'string') {
+                        var matched = /(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})\.\d+Z/g.exec(value) || [];
+                        return matched.length === 7
+                            ? new Date(matched[1], matched[2], matched[3], matched[4], matched[5], matched[6])
+                            : value;
+                    }
+                    return value;
+                });
 
                 if (firstCommentNode.previousSibling) {
                     removeEl(firstCommentNode.previousSibling);

--- a/src/view/for-node.js
+++ b/src/view/for-node.js
@@ -405,7 +405,9 @@ ForNode.prototype._updateArray = function (changes, newList) {
     var childrenNeedUpdate = {};
 
     var newLen = newList.length;
-    var getItemKey = bind(this.aNode._gfk, this.aNode);
+    var getItemKey = this.aNode._gfk
+        ? bind(this.aNode._gfk, this.aNode)
+        : this.aNode._gfk;
 
     /* eslint-disable no-redeclare */
     for (var cIndex = 0; cIndex < changes.length; cIndex++) {


### PR DESCRIPTION
1. this.aNode._gfk 可能为 undefined，而 bind 的第一个参数为必填，因此这里判断一下，避免执行 bind(this.aNode._gfk, this.aNode) 时抛出异常
2. 修复 JSON.parse 时由转义符导致的异常
3. 修复 JSON.parse 后 Date 数据类型异常的问题