### PR TITLE
fix: 修复s-is指令内不能调用实例方法的问题

### DIFF
--- a/src/view/is-node.js
+++ b/src/view/is-node.js
@@ -39,7 +39,7 @@ function IsNode(aNode, parent, scope, owner, hydrateWalker) {
     this.tagName = this.aNode.tagName;
     // #[begin] hydrate
     if (hydrateWalker) {
-        this.cmpt = evalExpr(this.aNode.directives.is.value, this.scope) || this.tagName;
+        this.cmpt = evalExpr(this.aNode.directives.is.value, this.scope, this.owner) || this.tagName;
         this.children[0] = createHydrateNode(
             this.aNode.isRinsed,
             this,
@@ -63,7 +63,7 @@ IsNode.prototype.dispose = nodeOwnSimpleDispose;
  * @param {HTMLElement＝} beforeEl 要添加到哪个元素之前
  */
 IsNode.prototype.attach = function (parentEl, beforeEl) {
-    this.cmpt = evalExpr(this.aNode.directives.is.value, this.scope) || this.tagName;
+    this.cmpt = evalExpr(this.aNode.directives.is.value, this.scope, this.owner) || this.tagName;
     
     var child = createNode(this.aNode.isRinsed, this, this.scope, this.owner, this.cmpt);
     this.children[0] = child;
@@ -77,7 +77,7 @@ IsNode.prototype.attach = function (parentEl, beforeEl) {
  */
 IsNode.prototype._update = function (changes) {
     var child = this.children[0];
-    var cmpt = evalExpr(this.aNode.directives.is.value, this.scope) || this.tagName;
+    var cmpt = evalExpr(this.aNode.directives.is.value, this.scope, this.owner) || this.tagName;
 
     if (cmpt === this.cmpt) {
         child._update(changes);

--- a/test/component.spec.js
+++ b/test/component.spec.js
@@ -966,6 +966,99 @@ describe("Component", function () {
         });
     });
 
+    it("s-is use component method", function () {
+        var Label = san.defineComponent({
+            template: '<span title="{{text}}">{{text}}</span>',
+            initData: function () {
+                return {
+                    text: 'erik'
+                }
+            }
+        });
+
+        var MyComponent = san.defineComponent({
+            components: {
+                'x-label': Label
+            },
+            initData: function () {
+                return {
+                    type: 'label'
+                }
+            },
+            getComponentName: function (type) {
+                return 'x-' + type;
+            },
+            template: '<div><test s-is="{{getComponentName(type)}}"/></div>'
+        });
+
+        var myComponent = new MyComponent();
+
+        var wrap = document.createElement('div');
+        document.body.appendChild(wrap);
+        myComponent.attach(wrap);
+
+        var span = wrap.getElementsByTagName('span')[0];
+        expect(span.title).toBe('erik');
+
+        myComponent.dispose();
+        document.body.removeChild(wrap);
+    });
+
+    it("s-is use component method update", function (done) {
+        var Label = san.defineComponent({
+            template: '<span title="{{text}}">{{text}}</span>',
+            initData: function () {
+                return {
+                    text: 'erik'
+                }
+            }
+        });
+
+        var H2 = san.defineComponent({
+            template: '<h2>{{text}}.baidu</h2>',
+            initData: function () {
+                return {
+                    text: 'erik'
+                }
+            }
+        });
+
+        var MyComponent = san.defineComponent({
+            components: {
+                'x-label': Label,
+                'x-h2': H2
+            },
+            initData: function () {
+                return {
+                    type: 'label'
+                }
+            },
+            getComponentName: function (type) {
+                return 'x-' + type;
+            },
+            template: '<div><test s-is="{{getComponentName(type)}}"/></div>'
+        });
+
+        var myComponent = new MyComponent();
+
+        var wrap = document.createElement('div');
+        document.body.appendChild(wrap);
+        myComponent.attach(wrap);
+
+        var span = wrap.getElementsByTagName('span')[0];
+        expect(span.title).toBe('erik');
+
+        myComponent.data.set('type', 'h2');
+        san.nextTick(function () {
+            var h2 = wrap.getElementsByTagName('h2')[0];
+            expect(h2.innerHTML).toBe('erik.baidu');
+
+            myComponent.dispose();
+            document.body.removeChild(wrap);
+            done();
+        });
+    });
+
     it("components in inherits structure", function () {
         var Span = san.defineComponent({});
         Span.template = '<span title="span">span</span>';


### PR DESCRIPTION
s-is指令在计算表达式的时候没有携带owner参数导致找不到对应的实例上的方法，参考其他指令的实现补充了owner参数